### PR TITLE
rapid cleanup; tiny optimizations. promise it is not too complicated in ...

### DIFF
--- a/pkgbuild-watch
+++ b/pkgbuild-watch
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ $# == 0 || $1 == '-h' || $1 == '--help' ]]; then
+if (( $# == 0  )) || [[ $1 == @(-h|--help) ]]; then
     echo "use: pkgbuild-watch /path/to/pkgbuilds"
     echo
     echo "path is searched for pkgbuilds"
@@ -15,31 +15,31 @@ if [[ $# == 0 || $1 == '-h' || $1 == '--help' ]]; then
 fi
 
 
-pkgbuild_path="$1"
-urlfile="$HOME/.urlwatch/pkgbuild-watch-urls.txt"
-tempurl="$(mktemp)"
+pkgbuild_path=$1
+urlfile=$HOME/.urlwatch/pkgbuild-watch-urls.txt
+tempurl=$(mktemp)
 mkdir -p "$HOME/.urlwatch"
 
-trap 'rm -f $tempurl{,.2}' INT TERM EXIT
+trap 'rm -f "$tempurl"{,.2}' INT TERM EXIT
 
 while read pkgbuild
 do
-    if [[ "$pkgbuild" == */repos/* ]]; then
+    if [[ $pkgbuild == */repos/* ]]; then
         continue
     fi
     unset _watch
     source "$pkgbuild"
-    if [[ "$_watch" == "none" ]]; then
+    if [[ $_watch == "none" ]]; then
         continue
     fi
-    if [[ "$_watch" == "package" ]]; then
-	[ -z "$pkgbase" ] && pkgbase="$pkgname"
-        _watch=$(expac -S "http://www.archlinux.org/packages/%r/$(uname -m)/%n/" $pkgbase)
+    if [[ $_watch == "package" ]]; then
+	[[ -z $pkgbase ]] && pkgbase=$pkgname
+        _watch=$(expac -S "http://www.archlinux.org/packages/%r/$(uname -m)/%n/" "$pkgbase")
     fi
-    if [[ "$_watch" == "" ]]; then
-        _watch="$url"
+    if [[ -z $_watch ]]; then
+        _watch=$url
     fi
-    if [[ "$_watch" != "" ]]; then
+    if [[ -n $_watch ]]; then
         echo "$_watch" >> "$tempurl"
     fi
 done < <(find -L "$pkgbuild_path" -name 'PKGBUILD')

--- a/pkgbuild-watch
+++ b/pkgbuild-watch
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if (( $# == 0  )) || [[ $1 == @(-h|--help) ]]; then
+if (( ! $# )) || [[ $1 == @(-h|--help) ]]; then
     echo "use: pkgbuild-watch /path/to/pkgbuilds"
     echo
     echo "path is searched for pkgbuilds"

--- a/urlwatch.sh
+++ b/urlwatch.sh
@@ -2,15 +2,15 @@
 
 # the original urlwatch is slow and buggy
 
-if [ $# -eq 0 ]; then
+if ((! $#)); then
     echo "cheap bash knockoff of urlwatch"
     echo "urlwatch.sh url-list.txt"
     exit
 fi
 
-urlfile="$1"
-diffargs=""
-cache="$HOME/.urlwatch/cache"
+urlfile=$1
+diffargs=
+cache=$HOME/.urlwatch/cache
 mkdir -p "$cache"
 
 COLOR1='\e[1;32m'
@@ -26,26 +26,27 @@ nap()  # none : none
 
 urlcheck()  # url : pretty print
 {
-    urlhash=$(sha1sum <<< "$1" | cut -d ' ' -f 1)
+    urlhash=$(sha1sum <<< "$1")
+    urlhash=${urlhash%% *}
     temp=$(mktemp)
     curl -s --connect-timeout 10 "$1" > "$temp"
-    if [ ! -s "$temp" ]; then
+    if [[ ! -s $temp ]]; then
         # failure, don't bother anyone with the diff
         rm -f "$temp"
         return
     fi
     html2text -o "$temp.txt" "$temp"
-    if [ ! -e "$cache/$urlhash" ]; then
+    if [[ ! -e $cache/$urlhash ]]; then
         cp "$temp.txt" "$cache/$urlhash"
     fi
-    diff -q "$temp.txt" "$cache/$urlhash" &> /dev/null
-    if [[ "$?" != "0" ]]; then
+    if ! diff -q "$temp.txt" "$cache/$urlhash" &> /dev/null; then
         diff $diffargs "$temp.txt" "$cache/$urlhash" > "$temp.diff"
         cp "$temp.txt" "$cache/$urlhash"
         # echo is atomic, fine for multithreaded stuff
-        echo -e "${COLOR1}${1}${ENDC}\n$(cat $temp.diff)\n\n"
+	# printf because nyeh *raspberry* $ help printf
+        printf '%b\n%s\n\n' "${COLOR1}${1}${ENDC}" "$(< $temp.diff)"
     fi
-    rm -f $temp{,.txt,.diff}
+    rm -f "$temp"{,.txt,.diff}
 }
 
 while read line; do


### PR DESCRIPTION
...the diffs =]

i admit to not testing any of this, but i'm 95% certain i didn't change any of the logic, just eliminated superfluous quotes, added some quotes where they are **technically** necessary (even if not strictly required for this script in particular), and made a few really tiny style changes.

also implemented a couple of tricks, namely `$(< file)`. ymmv on balancing so-called "readability" against the likely intangible speed boost of not exec'ing `cat`. does anyone care about that? probably not. i doubt you do. i technically don't. but when working with modern shells, i default to the special `$(< file)` because...because. just because. so there you go.
